### PR TITLE
Add powerDown function

### DIFF
--- a/Adafruit_PN532.cpp
+++ b/Adafruit_PN532.cpp
@@ -534,6 +534,15 @@ bool Adafruit_PN532::SAMConfig(void) {
   return (pn532_packetbuffer[offset] == 0x15);
 }
 
+bool Adafruit_PN532::powerDown() {
+    pn532_packetbuffer[0] = PN532_COMMAND_POWERDOWN;
+    pn532_packetbuffer[1] = 0xC0; // I2C or SPI Wakeup
+    pn532_packetbuffer[2] = 0x00; // no IRQ
+
+    return sendCommandCheckAck(pn532_packetbuffer, 3);
+}
+
+
 /**************************************************************************/
 /*!
     Sets the MxRtyPassiveActivation byte of the RFConfiguration register

--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -188,6 +188,7 @@ public:
   bool writeGPIO(uint8_t pinstate);
   uint8_t readGPIO(void);
   bool setPassiveActivationRetries(uint8_t maxRetries);
+  bool powerDown();
 
   // ISO14443A functions
   bool readPassiveTargetID(


### PR DESCRIPTION
This function set PN532 in powerDown mode and can be useful to save some energy if PN532 is not used or board is in DeepSleep