### PR TITLE
Lower timeout for FeliCa_Polling

### DIFF
--- a/Adafruit_PN532.h
+++ b/Adafruit_PN532.h
@@ -235,7 +235,7 @@ public:
   // Felica functions
   uint8_t felica_Polling(uint16_t systemCode, uint8_t requestCode, uint8_t *idm,
                          uint8_t *pmm, uint16_t *systemCodeResponse,
-                         uint16_t timeout = 1000);
+                         uint16_t timeout = 100);
   uint8_t felica_SendCommand(const uint8_t *command, uint8_t commandlength,
                              uint8_t responseLength);
   uint8_t felica_ReadWithoutEncryption(uint8_t numService,


### PR DESCRIPTION
This PR resolve issue https://github.com/pr3y/Bruce/issues/1238, FeliCa card reply in maximum 20.4 ms so 100ms is a reasonable timeout value like MIFARE one. 